### PR TITLE
ACEB-24 Send message on new votes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
     "build": "yarn run generate && npx ts-node build.ts",
     "lint": "npx eslint --ext .ts src/ tests/",
     "lint:tests": "npx eslint --ext .ts tests/",
-    "start": "npm run migrate:dev && node -r module-alias/register ./dist --env=production",
+    "start": "npm run prisma:deploy && node -r module-alias/register ./dist --env=production",
     "dev": "dotenvx run -f ./env/development.env -- nodemon",
     "test": "jest --env-file=./env/test.env",
     "test:coverage": "node --env-file ./env/test.env node_modules/.bin/jest --coverage --coverageDirectory=coverage",
-    "migrate:dev": "prisma migrate dev --schema ./src/prisma/schema.prisma",
-    "generate": "prisma generate --schema ./src/prisma/schema.prisma"
+    "prisma:deploy": "npx prisma migrate deploy"
+  },
+  "prisma": {
+    "schema": "./src/prisma/schema.prisma"
   },
   "nodemonConfig": {
     "watch": [

--- a/src/handlers/rounds/set-issue.ts
+++ b/src/handlers/rounds/set-issue.ts
@@ -24,7 +24,7 @@ async function setIssueHandler(request: SetIssueRequest, response: Response): Pr
   const issue = await setIssue(roundId, issueId, decrypt(user.token))
 
   response.status(HttpStatusCodes.NO_CONTENT)
-  sendMessageToRound(roundId, issue)
+  sendMessageToRound(roundId, { type: 'issue', payload: issue, event: 'roundIssueUpdated' })
 }
 
 export default setIssueHandler

--- a/src/handlers/rounds/set-vote.ts
+++ b/src/handlers/rounds/set-vote.ts
@@ -1,6 +1,9 @@
+import { PrismaClient } from '@prisma/client'
 import { Request, Response } from 'express'
 
 import HttpStatusCodes from '@aces/common/HttpStatusCodes'
+import getIssue from '@aces/services/issues/get-issue'
+import RoundNotifier from '@aces/services/rounds/round-notifier'
 import setVote from '@aces/services/rounds/set-vote'
 import canAccessRound from '@aces/util/can-access-round'
 
@@ -18,7 +21,20 @@ async function setVoteHandler(request: Request, response: Response): Promise<voi
     response.status(HttpStatusCodes.FORBIDDEN).json({ error: 'Forbidden' })
     return
   }
+  const prisma = new PrismaClient()
+  const round = await prisma.round.findUnique({ where: { id: roundId }, })
+  if (!round) {
+    response.status(HttpStatusCodes.NOT_FOUND).json({ error: 'Round not found' })
+    return
+  }
   await setVote(roundId, issueId, vote, user)
+  const roundNotifier = new RoundNotifier(round)
+  const issue = await getIssue({ roundId, linearId: issueId })
+  if (!issue) {
+    response.status(HttpStatusCodes.NOT_FOUND).json({ error: 'Issue not found' })
+    return
+  }
+  await roundNotifier.voteSet(issue)
   response.status(HttpStatusCodes.OK).json({ message: 'Estimate set' })
 }
 

--- a/src/interfaces/socket-message.ts
+++ b/src/interfaces/socket-message.ts
@@ -1,0 +1,29 @@
+import { Issue } from '@prisma/client'
+
+
+type SocketMessageType = 'vote' | 'issue' | 'round' | 'user'
+type SocketMessageEvent = 'voteUpdated' | 'roundIssueUpdated' | 'response' | 'error'
+
+interface SocketMessage {
+    event: SocketMessageEvent
+    type?: SocketMessageType
+    payload: object
+}
+
+interface VoteUpdatedPayload {
+    issueId: string
+    votes: number[]
+}
+
+interface VoteUpdatedMessage extends SocketMessage {
+    event: 'voteUpdated'
+    payload: VoteUpdatedPayload
+}
+
+interface RoundIssueChangedMessage extends SocketMessage {
+    event: 'roundIssueUpdated'
+    payload: Issue
+}
+
+export default SocketMessage
+export type { RoundIssueChangedMessage, SocketMessage, SocketMessageEvent, SocketMessageType, VoteUpdatedMessage, VoteUpdatedPayload }

--- a/src/services/rounds/round-notifier.ts
+++ b/src/services/rounds/round-notifier.ts
@@ -1,0 +1,29 @@
+import { Issue, PrismaClient, Round } from '@prisma/client'
+
+import { VoteUpdatedMessage } from '@aces/interfaces/socket-message'
+import sendMessageToRound from '@aces/socket/send-message-to-round'
+
+
+class RoundNotifier {
+  public round: Round
+  private db: PrismaClient = new PrismaClient()
+
+  public constructor(round: Round) {
+    this.round = round
+  }
+
+  public async voteSet(issue: Issue): Promise<void> {
+    const voteRecords = await this.db.vote.findMany({
+      where: {
+        issue: {
+          id: issue.id
+        }
+      },
+    })
+    const votes = voteRecords.map(vote => vote.vote)
+    const message: VoteUpdatedMessage = { event: 'voteUpdated', type: 'vote', payload: { issueId: issue.id, votes } }
+    sendMessageToRound(this.round.id, message)
+  }
+}
+
+export default RoundNotifier

--- a/src/socket/send-message-to-round.ts
+++ b/src/socket/send-message-to-round.ts
@@ -1,9 +1,10 @@
 import { WebSocket } from 'ws'
 
+import SocketMessage from '@aces/interfaces/socket-message'
 import { roundConnections } from '@aces/socket/setup-websocket'
 
 
-function sendMessageToRound(roundId: string, message: unknown): void {
+function sendMessageToRound(roundId: string, message: SocketMessage): void {
   const connections = roundConnections.get(roundId)
 
   if (connections && connections.size > 0) {

--- a/tests/handlers/rounds/set-issue.test.ts
+++ b/tests/handlers/rounds/set-issue.test.ts
@@ -77,7 +77,7 @@ describe('setIssueHandler', () => {
 
     expect(decrypt).toHaveBeenCalledWith(mockUser.token)
     expect(setIssue).toHaveBeenCalledWith(mockRequest.params?.roundId, mockRequest.body.issue, decryptedToken)
-    expect(sendMessageToRound).toHaveBeenCalledWith(mockRequest.params?.roundId, mockIssue)
+    expect(sendMessageToRound).toHaveBeenCalledWith(mockRequest.params?.roundId, { type: 'issue', payload: mockIssue, event: 'roundIssueUpdated' })
     expect(mockStatus).toHaveBeenCalledWith(HttpStatusCodes.NO_CONTENT)
   })
 })

--- a/tests/handlers/rounds/set-vote.test.ts
+++ b/tests/handlers/rounds/set-vote.test.ts
@@ -1,18 +1,38 @@
+import { PrismaClient } from '@prisma/client'
 import { Request, Response } from 'express'
 
 import HttpStatusCodes from '@aces/common/HttpStatusCodes'
 import setVoteHandler from '@aces/handlers/rounds/set-vote'
+import getIssue from '@aces/services/issues/get-issue'
+import RoundNotifier from '@aces/services/rounds/round-notifier'
 import setVote from '@aces/services/rounds/set-vote'
 import canAccessRound from '@aces/util/can-access-round'
 
 
+jest.mock('@prisma/client', () => {
+  const mockPrismaClient = {
+    round: {
+      findUnique: jest.fn()
+    }
+  }
+  return {
+    PrismaClient: jest.fn(() => mockPrismaClient)
+  }
+})
 jest.mock('@aces/services/rounds/set-vote')
 jest.mock('@aces/util/can-access-round')
+jest.mock('@aces/services/issues/get-issue')
+jest.mock('@aces/services/rounds/round-notifier')
 
 describe('setVoteHandler', () => {
   let mockRequest: Partial<Request>
   let mockResponse: Partial<Response>
   let mockUser: { id: string }
+  let mockPrismaClient: { round: { findUnique: jest.Mock } }
+  let mockRoundNotifier: jest.Mocked<RoundNotifier>
+  let mockCanAccessRound: jest.Mock
+  let mockGetIssue: jest.Mock
+  let mockSetVote: jest.Mock
 
   beforeEach(() => {
     mockUser = { id: 'user-1' }
@@ -25,16 +45,31 @@ describe('setVoteHandler', () => {
       status: jest.fn().mockReturnThis(),
       json: jest.fn()
     } as unknown as Response
+    mockPrismaClient = new PrismaClient() as unknown as { round: { findUnique: jest.Mock } }
+    mockRoundNotifier = {
+      voteSet: jest.fn()
+    } as unknown as jest.Mocked<RoundNotifier>
+    mockCanAccessRound = canAccessRound as jest.Mock
+    mockGetIssue = getIssue as jest.Mock
+    mockSetVote = setVote as jest.Mock
+    (RoundNotifier as jest.Mock).mockImplementation(() => mockRoundNotifier)
     jest.clearAllMocks()
   })
 
-  it('should set vote and return OK when user is authorized', async () => {
-    (canAccessRound as jest.Mock).mockResolvedValue(true)
+  it('should set vote and return OK when user is authorized and round and issue exist', async () => {
+    const mockRound = { id: 'round-1' }
+    const mockIssue = { id: 'issue-1', roundId: 'round-1', linearId: 'issue-1' }
+    mockCanAccessRound.mockResolvedValue(true)
+    mockPrismaClient.round.findUnique.mockResolvedValue(mockRound)
+    mockGetIssue.mockResolvedValue(mockIssue)
 
     await setVoteHandler(mockRequest as Request, mockResponse as Response)
 
-    expect(canAccessRound).toHaveBeenCalledWith('round-1', mockUser)
-    expect(setVote).toHaveBeenCalledWith('round-1', 'issue-1', 5, mockUser)
+    expect(mockCanAccessRound).toHaveBeenCalledWith('round-1', mockUser)
+    expect(mockPrismaClient.round.findUnique).toHaveBeenCalledWith({ where: { id: 'round-1' } })
+    expect(mockSetVote).toHaveBeenCalledWith('round-1', 'issue-1', 5, mockUser)
+    expect(mockGetIssue).toHaveBeenCalledWith({ roundId: 'round-1', linearId: 'issue-1' })
+    expect(mockRoundNotifier.voteSet).toHaveBeenCalledWith(mockIssue)
     expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCodes.OK)
     expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Estimate set' })
   })
@@ -44,20 +79,51 @@ describe('setVoteHandler', () => {
 
     await setVoteHandler(mockRequest as Request, mockResponse as Response)
 
-    expect(canAccessRound).not.toHaveBeenCalled()
-    expect(setVote).not.toHaveBeenCalled()
+    expect(mockCanAccessRound).not.toHaveBeenCalled()
+    expect(mockPrismaClient.round.findUnique).not.toHaveBeenCalled()
+    expect(mockSetVote).not.toHaveBeenCalled()
     expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCodes.UNAUTHORIZED)
     expect(mockResponse.json).toHaveBeenCalledWith({ error: 'Unauthorized' })
   })
 
   it('should return FORBIDDEN when user is not authorized to access the round', async () => {
-    (canAccessRound as jest.Mock).mockResolvedValue(false)
+    mockCanAccessRound.mockResolvedValue(false)
 
     await setVoteHandler(mockRequest as Request, mockResponse as Response)
 
-    expect(canAccessRound).toHaveBeenCalledWith('round-1', mockUser)
-    expect(setVote).not.toHaveBeenCalled()
+    expect(mockCanAccessRound).toHaveBeenCalledWith('round-1', mockUser)
+    expect(mockPrismaClient.round.findUnique).not.toHaveBeenCalled()
+    expect(mockSetVote).not.toHaveBeenCalled()
     expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCodes.FORBIDDEN)
     expect(mockResponse.json).toHaveBeenCalledWith({ error: 'Forbidden' })
+  })
+
+  it('should return NOT_FOUND when round does not exist', async () => {
+    mockCanAccessRound.mockResolvedValue(true)
+    mockPrismaClient.round.findUnique.mockResolvedValue(null)
+
+    await setVoteHandler(mockRequest as Request, mockResponse as Response)
+
+    expect(mockCanAccessRound).toHaveBeenCalledWith('round-1', mockUser)
+    expect(mockPrismaClient.round.findUnique).toHaveBeenCalledWith({ where: { id: 'round-1' } })
+    expect(mockSetVote).not.toHaveBeenCalled()
+    expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCodes.NOT_FOUND)
+    expect(mockResponse.json).toHaveBeenCalledWith({ error: 'Round not found' })
+  })
+
+  it('should return NOT_FOUND when issue does not exist', async () => {
+    const mockRound = { id: 'round-1' }
+    mockCanAccessRound.mockResolvedValue(true)
+    mockPrismaClient.round.findUnique.mockResolvedValue(mockRound)
+    mockGetIssue.mockResolvedValue(null)
+
+    await setVoteHandler(mockRequest as Request, mockResponse as Response)
+
+    expect(mockCanAccessRound).toHaveBeenCalledWith('round-1', mockUser)
+    expect(mockPrismaClient.round.findUnique).toHaveBeenCalledWith({ where: { id: 'round-1' } })
+    expect(mockSetVote).toHaveBeenCalledWith('round-1', 'issue-1', 5, mockUser)
+    expect(mockGetIssue).toHaveBeenCalledWith({ roundId: 'round-1', linearId: 'issue-1' })
+    expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCodes.NOT_FOUND)
+    expect(mockResponse.json).toHaveBeenCalledWith({ error: 'Issue not found' })
   })
 })

--- a/tests/services/rounds/round-notifier.ts
+++ b/tests/services/rounds/round-notifier.ts
@@ -1,0 +1,109 @@
+import { Issue, PrismaClient, Round, Vote } from '@prisma/client'
+
+import { VoteUpdatedMessage } from '@aces/interfaces/socket-message'
+import RoundNotifier from '@aces/services/rounds/round-notifier'
+import sendMessageToRound from '@aces/socket/send-message-to-round'
+
+
+jest.mock('@prisma/client', () => {
+  const mockPrismaClient = {
+    vote: {
+      findMany: jest.fn()
+    }
+  }
+  return {
+    PrismaClient: jest.fn(() => mockPrismaClient)
+  }
+})
+
+jest.mock('@aces/socket/send-message-to-round')
+
+describe('RoundNotifier', () => {
+  let roundNotifier: RoundNotifier
+  let mockRound: Round
+  let mockIssue: Issue
+  let mockPrismaClient: { vote: { findMany: jest.Mock } }
+  let mockSendMessageToRound: jest.Mock
+
+  beforeEach(() => {
+    mockRound = { id: 'round-1' } as Round
+    mockIssue = { id: 'issue-1' } as Issue
+    roundNotifier = new RoundNotifier(mockRound)
+    mockPrismaClient = new PrismaClient() as unknown as { vote: { findMany: jest.Mock } }
+    mockSendMessageToRound = sendMessageToRound as jest.Mock
+
+    jest.clearAllMocks()
+  })
+
+  it('should fetch votes and send a message when voteSet is called', async () => {
+    const mockVotes: Vote[] = [
+      { id: 'vote-1', vote: 3 },
+      { id: 'vote-2', vote: 5 }
+    ] as Vote[]
+
+    mockPrismaClient.vote.findMany.mockResolvedValue(mockVotes)
+
+    await roundNotifier.voteSet(mockIssue)
+
+    expect(mockPrismaClient.vote.findMany).toHaveBeenCalledWith({
+      where: {
+        issue: {
+          id: mockIssue.id
+        }
+      }
+    })
+
+    const expectedMessage: VoteUpdatedMessage = {
+      event: 'voteUpdated',
+      type: 'vote',
+      payload: {
+        issueId: mockIssue.id,
+        votes: [3, 5]
+      }
+    }
+
+    expect(mockSendMessageToRound).toHaveBeenCalledWith(mockRound.id, expectedMessage)
+  })
+
+  it('should send an empty votes array when no votes are found', async () => {
+    mockPrismaClient.vote.findMany.mockResolvedValue([])
+
+    await roundNotifier.voteSet(mockIssue)
+
+    expect(mockPrismaClient.vote.findMany).toHaveBeenCalledWith({
+      where: {
+        issue: {
+          id: mockIssue.id
+        }
+      }
+    })
+
+    const expectedMessage: VoteUpdatedMessage = {
+      event: 'voteUpdated',
+      type: 'vote',
+      payload: {
+        issueId: mockIssue.id,
+        votes: []
+      }
+    }
+
+    expect(mockSendMessageToRound).toHaveBeenCalledWith(mockRound.id, expectedMessage)
+  })
+
+  it('should handle errors when fetching votes', async () => {
+    const mockError = new Error('Database error')
+    mockPrismaClient.vote.findMany.mockRejectedValue(mockError)
+
+    await expect(roundNotifier.voteSet(mockIssue)).rejects.toThrow('Database error')
+
+    expect(mockPrismaClient.vote.findMany).toHaveBeenCalledWith({
+      where: {
+        issue: {
+          id: mockIssue.id
+        }
+      }
+    })
+
+    expect(mockSendMessageToRound).not.toHaveBeenCalled()
+  })
+})

--- a/tests/socket/send-message-to-round.test.ts
+++ b/tests/socket/send-message-to-round.test.ts
@@ -1,5 +1,6 @@
 import { WebSocket } from 'ws'
 
+import SocketMessage from '@aces/interfaces/socket-message'
 import sendMessageToRound from '@aces/socket/send-message-to-round'
 import { roundConnections } from '@aces/socket/setup-websocket'
 
@@ -31,7 +32,7 @@ describe('sendMessageToRound', () => {
 
   it('should send message to all open connections', () => {
     const roundId = 'round-1'
-    const message = { text: 'Hello, World!' }
+    const message = { event: 'voteUpdated', payload: {} } as SocketMessage
     const mockWebSocket = createMockWebSocket(WebSocket.OPEN)
 
     roundConnections.set(roundId, new Set([mockWebSocket]))
@@ -47,7 +48,7 @@ describe('sendMessageToRound', () => {
 
     roundConnections.set(roundId, new Set([mockWebSocket]))
 
-    sendMessageToRound(roundId, { text: 'Hello, World!' })
+    sendMessageToRound(roundId, { event: 'voteUpdated', payload: {} })
 
     expect(mockWebSocket.send).not.toHaveBeenCalled()
   })
@@ -56,7 +57,7 @@ describe('sendMessageToRound', () => {
     const roundId = 'round-3'
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
 
-    sendMessageToRound(roundId, { text: 'Hello, World!' })
+    sendMessageToRound(roundId, { event: 'voteUpdated', payload: {} })
 
     expect(consoleSpy).toHaveBeenCalledWith(`No active connections found for round ${roundId}`)
   })
@@ -68,7 +69,7 @@ describe('sendMessageToRound', () => {
 
     roundConnections.set(roundId, new Set([mockWebSocket]))
 
-    sendMessageToRound(roundId, { text: 'Hello, World!' })
+    sendMessageToRound(roundId, { event: 'voteUpdated', payload: {} })
 
     expect(consoleSpy).toHaveBeenCalledWith(`Client in round ${roundId} not ready. State: ${mockWebSocket.readyState}`)
   })


### PR DESCRIPTION
When a vote is set or updated on a round, notify all connections to the round using the new `SocketMessage` interface