### PR TITLE
ACEB-32 Send votes with initial issue response

### DIFF
--- a/src/handlers/rounds/set-issue.ts
+++ b/src/handlers/rounds/set-issue.ts
@@ -1,6 +1,9 @@
 import { Request, Response } from 'express'
 
 import HttpStatusCodes from '@aces/common/HttpStatusCodes'
+import getIssue from '@aces/services/issues/get-issue'
+import getIssueVotes from '@aces/services/issues/get-issue-votes'
+import getGuests from '@aces/services/rounds/get-guests'
 import setIssue from '@aces/services/rounds/set-issue'
 import sendMessageToRound from '@aces/socket/send-message-to-round'
 import decrypt from '@aces/util/encryption/decrypt'
@@ -22,9 +25,17 @@ async function setIssueHandler(request: SetIssueRequest, response: Response): Pr
   const roundId = request.params.roundId
   const issueId = request.body.issue
   const issue = await setIssue(roundId, issueId, decrypt(user.token))
-
+  const dbIssue = await getIssue({ roundId, linearId: issueId })
+  if (!dbIssue) {
+    response.status(HttpStatusCodes.NOT_FOUND).send('Issue not found in database')
+    return
+  }
+  const issueVotes = await getIssueVotes(dbIssue)
+  const votes = issueVotes.map(vote => vote.vote)
+  const roundGuests = await getGuests({ round: roundId })
+  const expectedVotes = roundGuests.length + 1 // Add 1 for the creator
   response.status(HttpStatusCodes.NO_CONTENT)
-  sendMessageToRound(roundId, { type: 'issue', payload: issue, event: 'roundIssueUpdated' })
+  sendMessageToRound(roundId, { type: 'issue', payload: { issue, votes, expectedVotes }, event: 'roundIssueUpdated' })
   response.send()
 }
 

--- a/src/services/issues/get-issue-votes.ts
+++ b/src/services/issues/get-issue-votes.ts
@@ -1,0 +1,14 @@
+import { Issue, PrismaClient, Vote } from '@prisma/client'
+
+
+const prisma = new PrismaClient()
+
+async function getIssueVotes(issue: Issue): Promise<Vote[]> {
+  return prisma.vote.findMany({
+    where: {
+      issueId: issue.id
+    }
+  })
+}
+
+export default getIssueVotes

--- a/src/services/issues/get-issue.ts
+++ b/src/services/issues/get-issue.ts
@@ -15,6 +15,9 @@ async function getIssue({ roundId, issueId, linearId }: GetIssueParams): Promise
       where: {
         id: issueId,
         roundId: roundId
+      },
+      include: {
+        votes: true
       }
     })
   }
@@ -23,6 +26,9 @@ async function getIssue({ roundId, issueId, linearId }: GetIssueParams): Promise
       where: {
         linearId: linearId,
         roundId: roundId
+      },
+      include: {
+        votes: true
       }
     })
   }

--- a/src/services/rounds/get-guests.ts
+++ b/src/services/rounds/get-guests.ts
@@ -1,0 +1,20 @@
+import { PrismaClient, Round, RoundGuest } from '@prisma/client'
+
+
+const prisma = new PrismaClient()
+
+
+type GetGuestsParams = { round?: string } | { round?: Round }
+
+async function getGuests({ round }: GetGuestsParams): Promise<RoundGuest[]> {
+  if (typeof round !== 'string') {
+    round = round!.id
+  }
+  return prisma.roundGuest.findMany({
+    where: {
+      roundId: round
+    }
+  })
+}
+
+export default getGuests

--- a/tests/handlers/rounds/set-issue.test.ts
+++ b/tests/handlers/rounds/set-issue.test.ts
@@ -1,19 +1,29 @@
 import { Issue } from '@linear/sdk'
-import { User } from '@prisma/client'
+import { User, Vote } from '@prisma/client'
 import { Request, Response } from 'express'
 
 import HttpStatusCodes from '@aces/common/HttpStatusCodes'
 import setIssueHandler from '@aces/handlers/rounds/set-issue'
+import getIssue from '@aces/services/issues/get-issue'
+import getIssueVotes from '@aces/services/issues/get-issue-votes'
+import getGuests from '@aces/services/rounds/get-guests'
 import setIssue from '@aces/services/rounds/set-issue'
 import sendMessageToRound from '@aces/socket/send-message-to-round'
 import decrypt from '@aces/util/encryption/decrypt'
 
 
 jest.mock('@aces/services/rounds/set-issue')
+jest.mock('@aces/services/issues/get-issue')
+jest.mock('@aces/services/issues/get-issue-votes')
+jest.mock('@aces/services/rounds/get-guests')
 jest.mock('@aces/socket/send-message-to-round')
 jest.mock('@aces/util/encryption/decrypt')
 
 const mockSetIssue = setIssue as jest.MockedFunction<typeof setIssue>
+const mockGetIssue = getIssue as jest.MockedFunction<typeof getIssue>
+const mockGetIssueVotes = getIssueVotes as jest.MockedFunction<typeof getIssueVotes>
+const mockGetGuests = getGuests as jest.MockedFunction<typeof getGuests>
+const mockSendMessageToRound = sendMessageToRound as jest.MockedFunction<typeof sendMessageToRound>
 const mockDecrypt = decrypt as jest.MockedFunction<typeof decrypt>
 
 describe('setIssueHandler', () => {
@@ -46,6 +56,12 @@ describe('setIssueHandler', () => {
       params: { roundId: 'test-round-id' },
       body: { issue: 'test-issue-id' },
     }
+
+    mockDecrypt.mockReturnValue('decrypted-token')
+    mockSetIssue.mockResolvedValue({ id: 'test-issue-id', linearId: 'test-linear-id', title: 'Test Issue' } as unknown as Issue)
+    mockGetIssue.mockResolvedValue({ id: 'test-issue-id', linearId: 'test-linear-id', roundId: 'test-round-id' })
+    mockGetIssueVotes.mockResolvedValue([{ vote: 1 }, { vote: 2 }] as Vote[])
+    mockGetGuests.mockResolvedValue([{ userId: 'guest-1', roundId: 'test-round-id' }, { userId: 'guest-2', roundId: 'test-round-id' }])
   })
 
   afterEach(() => {
@@ -62,8 +78,7 @@ describe('setIssueHandler', () => {
   })
 
   it('should return 401 if user does not have a linearId', async () => {
-    // @ts-expect-error Forcing a test case where linearId is undefined
-    mockRequest.user = { ...mockUser, linearId: undefined }
+    mockRequest.user = { ...mockUser, linearId: undefined } as unknown as User
 
     await setIssueHandler(mockRequest as Request, mockResponse as Response)
 
@@ -71,17 +86,32 @@ describe('setIssueHandler', () => {
     expect(mockSend).toHaveBeenCalledWith('Unauthorized')
   })
 
-  it('should set issue and send message to round', async () => {
-    const decryptedToken = 'decrypted-token'
-    mockDecrypt.mockReturnValue(decryptedToken)
-    const mockIssue = { id: 'test-issue-id', linearId: 'test-linear-id', title: 'Test Issue' } as unknown as Issue
-    mockSetIssue.mockResolvedValue(mockIssue)
+  it('should return 404 if issue is not found in database', async () => {
+    mockGetIssue.mockResolvedValue(null)
 
     await setIssueHandler(mockRequest as Request, mockResponse as Response)
 
-    expect(decrypt).toHaveBeenCalledWith(mockUser.token)
-    expect(setIssue).toHaveBeenCalledWith(mockRequest.params?.roundId, mockRequest.body.issue, decryptedToken)
-    expect(sendMessageToRound).toHaveBeenCalledWith(mockRequest.params?.roundId, { type: 'issue', payload: mockIssue, event: 'roundIssueUpdated' })
+    expect(mockStatus).toHaveBeenCalledWith(HttpStatusCodes.NOT_FOUND)
+    expect(mockSend).toHaveBeenCalledWith('Issue not found in database')
+  })
+
+  it('should set issue, get votes and guests, and send message to round', async () => {
+    await setIssueHandler(mockRequest as Request, mockResponse as Response)
+
+    expect(mockDecrypt).toHaveBeenCalledWith(mockUser.token)
+    expect(mockSetIssue).toHaveBeenCalledWith('test-round-id', 'test-issue-id', 'decrypted-token')
+    expect(mockGetIssue).toHaveBeenCalledWith({ roundId: 'test-round-id', linearId: 'test-issue-id' })
+    expect(mockGetIssueVotes).toHaveBeenCalledWith({ id: 'test-issue-id', linearId: 'test-linear-id', roundId: 'test-round-id' })
+    expect(mockGetGuests).toHaveBeenCalledWith({ round: 'test-round-id' })
+    expect(mockSendMessageToRound).toHaveBeenCalledWith('test-round-id', {
+      type: 'issue',
+      payload: {
+        issue: { id: 'test-issue-id', linearId: 'test-linear-id', title: 'Test Issue' },
+        votes: [1, 2],
+        expectedVotes: 3
+      },
+      event: 'roundIssueUpdated'
+    })
     expect(mockStatus).toHaveBeenCalledWith(HttpStatusCodes.NO_CONTENT)
     expect(mockSend).toHaveBeenCalled()
   })

--- a/tests/services/issues/get-issue-votes.test.ts
+++ b/tests/services/issues/get-issue-votes.test.ts
@@ -1,0 +1,82 @@
+import { Issue, PrismaClient, Vote } from '@prisma/client'
+
+import getIssueVotes from '@aces/services/issues/get-issue-votes'
+
+
+type MockPrismaClient = {
+  vote: {
+    findMany: jest.Mock
+  }
+}
+
+jest.mock('@prisma/client', () => {
+  const mockPrismaClient = {
+    vote: {
+      findMany: jest.fn(),
+    },
+  }
+
+  return {
+    PrismaClient: jest.fn(() => mockPrismaClient),
+  }
+})
+
+describe('getIssueVotes', () => {
+  let mockPrismaClient: MockPrismaClient
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    const MockedPrismaClass = PrismaClient as jest.MockedClass<typeof PrismaClient>
+    const prismaInstance = new MockedPrismaClass()
+    mockPrismaClient = prismaInstance as unknown as MockPrismaClient
+  })
+
+  it('should return votes for a given issue', async () => {
+    const mockIssue: Issue = { id: 'issue-1' } as Issue
+    const mockVotes: Vote[] = [
+      { id: 'vote-1', issueId: 'issue-1' } as Vote,
+      { id: 'vote-2', issueId: 'issue-1' } as Vote,
+    ]
+
+    mockPrismaClient.vote.findMany.mockResolvedValue(mockVotes)
+
+    const result = await getIssueVotes(mockIssue)
+
+    expect(result).toEqual(mockVotes)
+    expect(mockPrismaClient.vote.findMany).toHaveBeenCalledWith({
+      where: {
+        issueId: 'issue-1',
+      },
+    })
+  })
+
+  it('should return an empty array when no votes are found', async () => {
+    const mockIssue: Issue = { id: 'issue-2' } as Issue
+
+    mockPrismaClient.vote.findMany.mockResolvedValue([])
+
+    const result = await getIssueVotes(mockIssue)
+
+    expect(result).toEqual([])
+    expect(mockPrismaClient.vote.findMany).toHaveBeenCalledWith({
+      where: {
+        issueId: 'issue-2',
+      },
+    })
+  })
+
+  it('should throw an error when the database query fails', async () => {
+    const mockIssue: Issue = { id: 'issue-3' } as Issue
+    const mockError = new Error('Database query failed')
+
+    mockPrismaClient.vote.findMany.mockRejectedValue(mockError)
+
+    await expect(getIssueVotes(mockIssue)).rejects.toThrow('Database query failed')
+    expect(mockPrismaClient.vote.findMany).toHaveBeenCalledWith({
+      where: {
+        issueId: 'issue-3',
+      },
+    })
+  })
+})

--- a/tests/services/issues/get-issue.test.ts
+++ b/tests/services/issues/get-issue.test.ts
@@ -38,6 +38,9 @@ describe('getIssue', () => {
       where: {
         id: 'issue-1',
         roundId: 'round-1'
+      },
+      include: {
+        votes: true
       }
     })
     expect(mockPrismaClient.issue.findFirst).not.toHaveBeenCalled()
@@ -54,6 +57,9 @@ describe('getIssue', () => {
       where: {
         linearId: 'linear-1',
         roundId: 'round-1'
+      },
+      include: {
+        votes: true
       }
     })
     expect(mockPrismaClient.issue.findUnique).not.toHaveBeenCalled()
@@ -69,6 +75,9 @@ describe('getIssue', () => {
       where: {
         id: 'non-existent',
         roundId: 'round-1'
+      },
+      include: {
+        votes: true
       }
     })
   })
@@ -83,6 +92,9 @@ describe('getIssue', () => {
       where: {
         linearId: 'non-existent',
         roundId: 'round-1'
+      },
+      include: {
+        votes: true
       }
     })
   })

--- a/tests/services/rounds/get-guests.test.ts
+++ b/tests/services/rounds/get-guests.test.ts
@@ -1,0 +1,84 @@
+import { PrismaClient, Round, RoundGuest } from '@prisma/client'
+
+import getGuests from '@aces/services/rounds/get-guests'
+
+
+jest.mock('@prisma/client', () => {
+  const mockPrismaClient = {
+    roundGuest: {
+      findMany: jest.fn(),
+    },
+  }
+  return {
+    PrismaClient: jest.fn(() => mockPrismaClient),
+  }
+})
+
+
+describe('getGuests', () => {
+  const mockPrismaClient = new PrismaClient() as jest.Mocked<PrismaClient>
+  const mockFindMany = mockPrismaClient.roundGuest.findMany as jest.MockedFunction<typeof mockPrismaClient.roundGuest.findMany>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should fetch guests when given a round id string', async () => {
+    const mockRoundId = 'test-round-id'
+    const mockGuests: RoundGuest[] = [
+      { userId: 'user1', roundId: mockRoundId },
+      { userId: 'user2', roundId: mockRoundId },
+    ]
+
+    mockFindMany.mockResolvedValue(mockGuests)
+
+    const result = await getGuests({ round: mockRoundId })
+
+    expect(result).toEqual(mockGuests)
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { roundId: mockRoundId },
+    })
+  })
+
+  it('should fetch guests when given a Round object', async () => {
+    const mockRound: Round = { id: 'test-round-id' } as Round
+    const mockGuests: RoundGuest[] = [
+      { userId: 'user1', roundId: mockRound.id },
+      { userId: 'user2', roundId: mockRound.id },
+    ]
+
+    mockFindMany.mockResolvedValue(mockGuests)
+
+    const result = await getGuests({ round: mockRound })
+
+    expect(result).toEqual(mockGuests)
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { roundId: mockRound.id },
+    })
+  })
+
+  it('should handle an empty result', async () => {
+    const mockRoundId = 'empty-round-id'
+
+    mockFindMany.mockResolvedValue([])
+
+    const result = await getGuests({ round: mockRoundId })
+
+    expect(result).toEqual([])
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { roundId: mockRoundId },
+    })
+  })
+
+  it('should throw an error when Prisma query fails', async () => {
+    const mockRoundId = 'error-round-id'
+    const mockError = new Error('Database error')
+
+    mockFindMany.mockRejectedValue(mockError)
+
+    await expect(getGuests({ round: mockRoundId })).rejects.toThrow('Database error')
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { roundId: mockRoundId },
+    })
+  })
+})

--- a/tests/socket/send-current-issue.test.ts
+++ b/tests/socket/send-current-issue.test.ts
@@ -1,9 +1,10 @@
 import { Issue } from '@linear/sdk'
-import { PrismaClient, Round } from '@prisma/client'
+import { PrismaClient, Round, Vote } from '@prisma/client'
 import { WebSocket } from 'ws'
 
 import { WebSocketCloseCode } from '@aces/common/WebSocketCodes'
 import getLinearIssue from '@aces/linear/get-linear-issue'
+import getIssueVotes from '@aces/services/issues/get-issue-votes'
 import sendCurrentIssue from '@aces/socket/send-current-issue'
 import sendMessageToRound from '@aces/socket/send-message-to-round'
 import decrypt from '@aces/util/encryption/decrypt'
@@ -33,10 +34,12 @@ jest.mock('@prisma/client', () => {
 
 jest.mock('@aces/linear/get-linear-issue')
 jest.mock('@aces/util/encryption/decrypt')
+jest.mock('@aces/services/issues/get-issue-votes')
 jest.mock('@aces/socket/send-message-to-round')
 
 const mockGetLinearIssue = getLinearIssue as jest.MockedFunction<typeof getLinearIssue>
 const mockDecrypt = decrypt as jest.MockedFunction<typeof decrypt>
+const mockGetIssueVotes = getIssueVotes as jest.MockedFunction<typeof getIssueVotes>
 const mockSendMessageToRound = sendMessageToRound as jest.MockedFunction<typeof sendMessageToRound>
 
 describe('sendCurrentIssue', () => {
@@ -71,17 +74,18 @@ describe('sendCurrentIssue', () => {
       currentIssue: { linearId: 'issue_123' }
     } as unknown as Round
     const mockIssue = { id: 'issue_123', title: 'Test Issue' } as Issue
+    const mockIssueVotes = [{ vote: 1 }, { vote: 2 }] as Vote[]
 
     mockPrismaClient.round.findUnique.mockResolvedValue(mockRound)
     mockDecrypt.mockReturnValue('decrypted_token')
+    mockGetIssueVotes.mockResolvedValue(mockIssueVotes)
     mockGetLinearIssue.mockResolvedValue(mockIssue)
 
     await sendCurrentIssue('round_123', mockWs)
 
     expect(mockDecrypt).toHaveBeenCalledWith('encrypted_token')
     expect(mockGetLinearIssue).toHaveBeenCalledWith('issue_123', 'decrypted_token')
-    expect(mockSendMessageToRound).toHaveBeenCalledWith('round_123', { type: 'issue', payload: mockIssue, event: 'response' })
-    expect(consoleSpy).toHaveBeenCalledWith('Sending current issue for round round_123')
+    expect(mockSendMessageToRound).toHaveBeenCalledWith('round_123', { type: 'issue', payload: { issue: mockIssue, votes: [1, 2] }, event: 'response' })
   })
 
   it('should close the connection if round is not found', async () => {


### PR DESCRIPTION
Enhanced issue payload to include votes and expectedVotes. Added `getIssueVotes` and `getGuests` services, and updated `setIssueHandler` to integrate them correctly.